### PR TITLE
Report imported vs skipped orders in upload-orders-shopify response

### DIFF
--- a/src/controllers/upload-orders.js
+++ b/src/controllers/upload-orders.js
@@ -796,7 +796,8 @@ exports.uploadOrdersToLocalDatabaseShopify = async (req, res) => {
       // (list_pending_orders). The two lookups are independent, so run them in parallel. Matched by
       // order_po. account_key comes from payment_token for this endpoint, account_key as fallback.
       const orderPosToCheck = orders.map((o) => o.order_po).filter(Boolean);
-      const existingOrderPos = new Set();
+      const existingRealOrderPos = new Set();
+      const existingPendingOrderPos = new Set();
       if (orderPosToCheck.length) {
         const accountKeyForLookup = reqBody.payment_token || reqBody.account_key || null;
         const [listOrdersResult, listPendingResult] = await Promise.allSettled([
@@ -811,7 +812,7 @@ exports.uploadOrdersToLocalDatabaseShopify = async (req, res) => {
 
         if (listOrdersResult.status === "fulfilled") {
           for (const o of (Array.isArray(listOrdersResult.value?.orders) ? listOrdersResult.value.orders : [])) {
-            existingOrderPos.add(String(o.order_po));
+            existingRealOrderPos.add(String(o.order_po));
           }
         } else {
           log("list_orders lookup failed; proceeding without that check: %s", listOrdersResult.reason?.message);
@@ -819,16 +820,26 @@ exports.uploadOrdersToLocalDatabaseShopify = async (req, res) => {
 
         if (listPendingResult.status === "fulfilled") {
           for (const o of (Array.isArray(listPendingResult.value?.orders) ? listPendingResult.value.orders : [])) {
-            existingOrderPos.add(String(o.order_po));
+            existingPendingOrderPos.add(String(o.order_po));
           }
         } else {
           log("list_pending_orders lookup failed; proceeding without that check: %s", listPendingResult.reason?.message);
         }
       }
 
+      const importedOrderPos = [];
+      const skippedAlreadySubmittedOrderPos = [];
+      const skippedAlreadyPendingOrderPos = [];
       for (const order of orders) {
-        if (existingOrderPos.has(String(order.order_po))) {
-          log("Skipping order_po %s — already exists in FinerWorks", order.order_po);
+        const orderPoKey = String(order.order_po);
+        if (existingRealOrderPos.has(orderPoKey)) {
+          log("Skipping order_po %s — already exists as a submitted order in FinerWorks", order.order_po);
+          skippedAlreadySubmittedOrderPos.push(order.order_po);
+          continue;
+        }
+        if (existingPendingOrderPos.has(orderPoKey)) {
+          log("Skipping order_po %s — already staged as a pending order in FinerWorks", order.order_po);
+          skippedAlreadyPendingOrderPos.push(order.order_po);
           continue;
         }
         if (Array.isArray(order.order_items)) {
@@ -852,25 +863,34 @@ exports.uploadOrdersToLocalDatabaseShopify = async (req, res) => {
         const saveData = await finerworksService.SAVE_PENDING_ORDERS(savePayload);
         log("Response after save_pending_orders %s", JSON.stringify(saveData));
         order.orderFullFillmentId = extractSavedPendingOrderId(saveData);
+        importedOrderPos.push(order.order_po);
       }
       const successLog = JSON.stringify({
         level: 'INFO',
         platform: 'finerworks',
         method: req.method,
         api: req.originalUrl || req.url,
-        function: 'uploadOrdersToLocalDatabase',
+        function: 'uploadOrdersToLocalDatabaseShopify',
         operation: 'Orders uploaded to local database successfully',
         account_key: reqBody?.account_key || 'unknown',
-        result: { count: orders?.length || 0 },
+        result: {
+          count: orders?.length || 0,
+          imported: importedOrderPos.length,
+          skippedAlreadySubmitted: skippedAlreadySubmittedOrderPos.length,
+          skippedAlreadyPending: skippedAlreadyPendingOrderPos.length,
+        },
         timestamp: new Date().toISOString()
       });
       console.log(successLog);
-      log('Success in uploadOrdersToLocalDatabase: %s', successLog);
+      log('Success in uploadOrdersToLocalDatabaseShopify: %s', successLog);
       res.status(200).json({
         statusCode: 200,
         status: true,
-        message: "Orders have been submitted successfully",
+        message: `Orders processed: ${importedOrderPos.length} imported, ${skippedAlreadySubmittedOrderPos.length} skipped (already a submitted order), ${skippedAlreadyPendingOrderPos.length} skipped (already pending)`,
         data: orders,
+        imported_order_pos: importedOrderPos,
+        skipped_already_submitted_order_pos: skippedAlreadySubmittedOrderPos,
+        skipped_already_pending_order_pos: skippedAlreadyPendingOrderPos,
       });
     }
   } catch (err) {
@@ -880,7 +900,7 @@ exports.uploadOrdersToLocalDatabaseShopify = async (req, res) => {
       level: 'ERROR',
       platform: 'finerworks',
       source: isFinerworksError ? 'finerworks_api' : 'lambda',
-      function: 'uploadOrdersToLocalDatabase',
+      function: 'uploadOrdersToLocalDatabaseShopify',
       account_key: req.body?.account_key || 'unknown',
       httpStatus: err?.response?.status || null,
       message: `Failed to upload orders to local database: ${err?.message || 'Unknown error'}`,
@@ -888,7 +908,12 @@ exports.uploadOrdersToLocalDatabaseShopify = async (req, res) => {
       timestamp: new Date().toISOString()
     });
     console.error(errorJson);
-    log('Formatted error in uploadOrdersToLocalDatabase: %s', errorJson);
+    log('Formatted error in uploadOrdersToLocalDatabaseShopify: %s', errorJson);
+    res.status(err?.response?.status && err.response.status < 500 ? err.response.status : 400).json({
+      statusCode: 400,
+      status: false,
+      message: `Failed to upload orders to local database: ${err?.response?.data?.Message || err?.message || 'Unknown error'}`,
+    });
   }
 };
 


### PR DESCRIPTION
The dedup guard silently skipped order_pos that already exist in FinerWorks (as a submitted order or an already-pending one) while still returning a blanket "submitted successfully" message, making it look like nothing was imported when in fact some orders legitimately already existed. Also restores the response in the catch block, which was missing here (present in the other two upload-orders handlers) and caused failed requests to hang instead of returning an error.